### PR TITLE
Remove dependency on the PureScript compiler

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -68,7 +68,6 @@ description:         Please see the README on GitHub at <https://github.com/nate
 
 dependencies:
 - base >= 4.7 && < 5
-- purescript == 0.12.1
 - prettyprinter == 1.2.1
 - megaparsec == 7.0.4
 - text

--- a/purescript-cst.cabal
+++ b/purescript-cst.cabal
@@ -1,8 +1,10 @@
--- This file has been generated from package.yaml by hpack version 0.28.2.
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a9a1dab08212b4888d3a70a80ef012631da6bfd41f0d7fd9987bd6b736155d8e
+-- hash: 02bbe1841b3fcf59c1a8265d6b6f4b4f673805f16aa20f79eae22115266722f9
 
 name:           purescript-cst
 version:        0.1.0.0
@@ -14,7 +16,6 @@ copyright:      2019 Nathan Faubion
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
-cabal-version:  >= 1.10
 extra-source-files:
     README.md
 
@@ -50,7 +51,6 @@ library
     , mtl
     , pretty-simple
     , prettyprinter ==1.2.1
-    , purescript ==0.12.1
     , text
   default-language: Haskell2010
 
@@ -73,7 +73,6 @@ executable purescript-cst-exe
     , mtl
     , pretty-simple
     , prettyprinter ==1.2.1
-    , purescript ==0.12.1
     , purescript-cst
     , text
   default-language: Haskell2010
@@ -98,7 +97,6 @@ test-suite purescript-cst-test
     , mtl
     , pretty-simple
     , prettyprinter ==1.2.1
-    , purescript ==0.12.1
     , purescript-cst
     , text
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,4 @@ resolver: lts-12.21
 packages:
 - .
 extra-deps:
-- purescript-0.12.1
 - megaparsec-7.0.4


### PR DESCRIPTION
Hi! I'd like to try this out in Spago (usecase: possible implementation path for https://github.com/spacchetti/spago/issues/89), but I would not like to depend on the whole PureScript compiler, hence this PR 🙂 

It looks like the dependency was not in use, but maybe you had plans?